### PR TITLE
Add reStructuredText linter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,7 +50,7 @@ Released 2017-05-22
 
 * Adds support for boolean functions within filters
 * Adds the possibility of supplying a single dictionary as filters when
-only one filter is provided
+  only one filter is provided
 * Makes the `op` filter attribute optional: `==` is the default operator
 
 Version 0.2.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include CHANGELOG.rst
+include LICENSE
+include README.rst
+
+global-exclude __pycache__
+global-exclude *.pyc

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 .PHONY: test
 
 
+rst-lint:
+	rst-lint README.rst
+	rst-lint CHANGELOG.rst
+
 flake8:
 	flake8 sqlalchemy_filters test
 
 test: flake8
-	@py.test test $(ARGS)
+	pytest test $(ARGS)
 
-coverage: flake8
+coverage: flake8 rst-lint
 	coverage run --source sqlalchemy_filters -m pytest test $(ARGS)
 	coverage report -m --fail-under 100

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,17 @@ SQLAlchemy-filters
     Filter, sort and paginate SQLAlchemy query objects.
     Ideal for exposing these actions over a REST API.
 
+
+.. image:: https://img.shields.io/pypi/v/sqlalchemy-filters.svg
+    :target: https://pypi.org/project/sqlalchemy-filters/
+
+.. image:: https://img.shields.io/pypi/pyversions/sqlalchemy-filters.svg
+    :target: https://pypi.org/project/sqlalchemy-filters/
+
+.. image:: https://travis-ci.org/juliotrigo/sqlalchemy-filters.svg?branch=master
+    :target: https://travis-ci.org/juliotrigo/sqlalchemy-filters
+
+
 Filtering
 ---------
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ setup(
             'flake8==3.2.1',
             'coverage==4.3.1',
             'sqlalchemy-utils==0.32.12',
+            'restructuredtext-lint==1.2.2',
+            'Pygments==2.3.1',
         ],
         'mysql': [
             'mysql-connector-python-rf==2.1.3',

--- a/setup.py
+++ b/setup.py
@@ -25,15 +25,15 @@ setup(
     ],
     extras_require={
         'dev': [
-            'pytest==3.0.5',
-            'flake8==3.2.1',
-            'coverage==4.3.1',
-            'sqlalchemy-utils==0.32.12',
+            'pytest==4.3.0',
+            'flake8==3.7.6',
+            'coverage==4.5.2',
+            'sqlalchemy-utils==0.33.11',
             'restructuredtext-lint==1.2.2',
             'Pygments==2.3.1',
         ],
         'mysql': [
-            'mysql-connector-python-rf==2.1.3',
+            'mysql-connector-python-rf==2.2.2',
         ],
         'python2': [
             "funcsigs>=1.0.2"

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 [tox]
 envlist = {py27, py34, py35, py36, py37}
-skipdist=True
+skipsdist = True
 
 [testenv]
 whitelist_externals = make
+usedevelop = true
+extras =
+    dev
+    mysql
 deps =
     py27: funcsigs
-
 commands =
-    pip install -U --editable ".[dev, mysql]"
     make coverage ARGS='-x -vv'


### PR DESCRIPTION
Add a reStructuredText linter to check that all the documentation files are syntactically correct.

Trying to make sure that the reStructuredText `README.rst` file can always be rendered on PyPI (currently broken).

Changes:
* reStructuredText:
  * Add linter
  * Fix `CHANGELOG.rst` syntax
  * Add status images to the README file
* Add `MANIFEST.in` file
* Update `dev` packages
* Tox:
  * Use settings for develop mode and install extra packages
  * Amend `skipsdist` setting