### PR TITLE
Add test coverage for PostgreSQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
+
 language: python
+python: 3.7
+
+dist: xenial
 
 services:
   - mysql
@@ -28,7 +32,6 @@ matrix:
     - stage: test
       python: 3.7
       env: TOX_ENV=py37
-      dist: xenial
 
     - stage: deploy
       script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,13 @@ python: 3.7
 
 dist: xenial
 
-# Keep DB versions synchronized with the ones in the Makefile for local testing
 services:
-  - mysql
+  - docker
 
-addons:
-  postgresql: "9.6"
+before_install:
+  - docker --version
+  - make docker-mysql-run
+  - make docker-postgres-run
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,12 @@ services:
 
 addons:
   apt:
+    update: true
     packages:
       - docker-ce
 
 before_install:
+  - docker --version
   - make docker-mysql-run
   - make docker-postgres-run
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python: 3.7
 
 dist: xenial
 
+# Keep DB versions synchronized with the ones in the Makefile for local testing
 services:
   - mysql
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,12 @@ dist: xenial
 services:
   - docker
 
+addons:
+  apt:
+    packages:
+      - docker-ce
+
 before_install:
-  - docker --version
   - make docker-mysql-run
   - make docker-postgres-run
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,7 @@ dist: xenial
 services:
   - docker
 
-addons:
-  apt:
-    update: true
-    packages:
-      - docker-ce
-
 before_install:
-  - docker --version
   - make docker-mysql-run
   - make docker-postgres-run
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ services:
   - mysql
   - postgresql
 
-addons:
-  postgresql: "10"
-
 install:
   - pip install tox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ dist: xenial
 
 services:
   - mysql
-  - postgresql
+
+addons:
+  postgresql: "9.6"
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ dist: xenial
 
 services:
   - mysql
+  - postgresql
+
+addons:
+  postgresql: "10"
 
 install:
   - pip install tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Version 0.8.0
 
 Released 2018-06-25
 
-* Adds support for `ilike` (case-insensitive) string comparison.
+* Adds support for ``ilike`` (case-insensitive) string comparison.
 
 
 Version 0.7.0
@@ -51,7 +51,8 @@ Released 2017-05-22
 * Adds support for boolean functions within filters
 * Adds the possibility of supplying a single dictionary as filters when
   only one filter is provided
-* Makes the `op` filter attribute optional: `==` is the default operator
+* Makes the ``op`` filter attribute optional: ``==`` is the default
+  operator
 
 Version 0.2.0
 -------------

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 .PHONY: test
 
-# Versions used by Travis CI. Keep them synchronized.
 POSTGRES_VERSION?=9.6
 MYSQL_VERSION?=5.7
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test
 
 # Versions used by Travis CI. Keep them synchronized.
-POSTGRES_VERSION?=9.6.9
+POSTGRES_VERSION?=9.6
 MYSQL_VERSION?=5.7
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: test
 
+# Versions used by Travis CI. Keep them synchronized.
 POSTGRES_VERSION?=9.6.9
 MYSQL_VERSION?=5.7
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ coverage: flake8 rst-lint
 # Docker test containers
 
 docker-mysql-run:
-	docker run -d --name mysql-postgres-sqlalchemy-filters -p 3306:3306 \
+	docker run -d --name mysql-sqlalchemy-filters -p 3306:3306 \
 		-e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
 		mysql:$(MYSQL_VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: test
 
+POSTGRES_VERSION?=9.6.9
+MYSQL_VERSION?=5.7
+
 
 rst-lint:
 	rst-lint README.rst
@@ -14,3 +17,19 @@ test: flake8
 coverage: flake8 rst-lint
 	coverage run --source sqlalchemy_filters -m pytest test $(ARGS)
 	coverage report -m --fail-under 100
+
+
+# Docker test containers
+
+docker-mysql-run:
+	docker run -d --name mysql-postgres-sqlalchemy-filters -p 3306:3306 \
+		-e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+		mysql:$(MYSQL_VERSION)
+
+docker-postgres-run:
+	docker run -d --name postgres-sqlalchemy-filters -p 5432:5432 \
+		-e POSTGRES_USER=postgres \
+		-e POSTGRES_PASSWORD= \
+		-e POSTGRES_DB=test_sqlalchemy_filters \
+		-e POSTGRES_INITDB_ARGS="--encoding=UTF8 --lc-collate=en_US.utf8 --lc-ctype=en_US.utf8" \
+		postgres:$(POSTGRES_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,12 @@ coverage: flake8 rst-lint
 # Docker test containers
 
 docker-mysql-run:
-	docker run -d --name mysql-sqlalchemy-filters -p 3306:3306 \
+	docker run -d --rm --name mysql-sqlalchemy-filters -p 3306:3306 \
 		-e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
 		mysql:$(MYSQL_VERSION)
 
 docker-postgres-run:
-	docker run -d --name postgres-sqlalchemy-filters -p 5432:5432 \
+	docker run -d --rm --name postgres-sqlalchemy-filters -p 5432:5432 \
 		-e POSTGRES_USER=postgres \
 		-e POSTGRES_PASSWORD= \
 		-e POSTGRES_DB=test_sqlalchemy_filters \

--- a/README.rst
+++ b/README.rst
@@ -329,7 +329,7 @@ the tests, with the following URIs:
     postgresql+psycopg2://postgres:@localhost:5432/test_sqlalchemy_filters?client_encoding=utf8'
 
 A test database will be created, used during the tests and destroyed
-afterwards for each RDMS configured.
+afterwards for each RDBMS configured.
 
 There are Makefile targets to run docker containers locally for both
 **MySQL** and **PostgreSQL**, using the default ports and configuration:
@@ -367,7 +367,7 @@ There are some other Makefile targets that can be used to run the tests:
 Database management systems
 ---------------------------
 
-The following database management systems are supported (with test coverage):
+The following RDBMS are supported (tested):
 
 - SQLite
 - MySQL

--- a/README.rst
+++ b/README.rst
@@ -409,7 +409,7 @@ The following RDBMS are supported (tested):
 Python 2
 --------
 
-There is no active support for python 2, however it is compatiable as of
+There is no active support for python 2, however it is compatible as of
 February 2019, if you install ``funcsigs``.
 
 

--- a/README.rst
+++ b/README.rst
@@ -110,17 +110,20 @@ blocks is identical:
     ]
     filtered_query = apply_filters(query, filter_spec)
 
-The automatic join is only possible if sqlalchemy can implictly determine
-the condition for the join, for example because of a foreign key relationship.
+The automatic join is only possible if sqlalchemy can implictly
+determine the condition for the join, for example because of a foreign
+key relationship.
 
-Automatic joins allow flexibility for clients to filter and sort by related
-objects without specifying all possible joins on the server beforehand.
+Automatic joins allow flexibility for clients to filter and sort by
+related objects without specifying all possible joins on the server
+beforehand.
 
 Note that first filter of the second block does not specify a model.
 It is implictly applied to the ``Foo`` model because that is the only
 model in the original query passed to ``apply_filters``.
 
-It is also possible to apply filters to queries defined by fields or functions:
+It is also possible to apply filters to queries defined by fields or
+functions:
 
 .. code-block:: python
 
@@ -131,8 +134,8 @@ It is also possible to apply filters to queries defined by fields or functions:
 Restricted Loads
 ----------------
 
-You can restrict the fields that SQLAlchemy loads from the database by using
-the ``apply_loads`` function:
+You can restrict the fields that SQLAlchemy loads from the database by
+using the ``apply_loads`` function:
 
 .. code-block:: python
 
@@ -153,9 +156,9 @@ loaded during normal query execution.
 Effect on joined queries
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The default SQLAlchemy join is lazy, meaning that columns from the joined
-table are loaded only when required. Therefore ``apply_loads`` has limited
-effect in the following scenario:
+The default SQLAlchemy join is lazy, meaning that columns from the
+joined table are loaded only when required. Therefore ``apply_loads``
+has limited effect in the following scenario:
 
 .. code-block:: python
 
@@ -173,7 +176,8 @@ This is because a joined eager load does not add the joined model to the
 original query, as explained
 `here <http://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html#the-zen-of-joined-eager-loading>`_
 
-The following would not prevent all columns from Bar being eagerly loaded:
+The following would not prevent all columns from Bar being eagerly
+loaded:
 
 .. code-block:: python
 
@@ -188,8 +192,8 @@ The following would not prevent all columns from Bar being eagerly loaded:
 
     In fact, what happens here is that ``Bar`` is automatically joined
     to ``query``, because it is determined that ``Bar`` is not part of
-    the original query. The ``load_spec`` therefore has no effect because
-    the automatic join results in lazy evaluation.
+    the original query. The ``load_spec`` therefore has no effect
+    because the automatic join results in lazy evaluation.
 
 If you wish to perform a joined load with restricted columns, you must
 specify the columns as part of the joined load, rather than with
@@ -346,9 +350,9 @@ Running tests
 -------------
 
 The default configuration uses **SQLite**, **MySQL** (if the driver is
-installed, which is the case when ``tox`` is used) and **PostgreSQL** (if
-the driver is installed, which is the case when ``tox`` is used) to run
-the tests, with the following URIs:
+installed, which is the case when ``tox`` is used) and **PostgreSQL**
+(if the driver is installed, which is the case when ``tox`` is used) to
+run the tests, with the following URIs:
 
 .. code-block:: shell
 
@@ -405,7 +409,8 @@ The following RDBMS are supported (tested):
 Python 2
 --------
 
-There is no active support for python 2, however it is compatiable as of February 2019, if you install ``funcsigs``.
+There is no active support for python 2, however it is compatiable as of
+February 2019, if you install ``funcsigs``.
 
 
 License

--- a/README.rst
+++ b/README.rst
@@ -377,7 +377,7 @@ The following database management systems are supported (with test coverage):
 Python 2
 --------
 
-There is no active support for python 2, however it is compatiable as of February 2019, if you install funcsigs.
+There is no active support for python 2, however it is compatiable as of February 2019, if you install `funcsigs`.
 
 
 License

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ SQLAlchemy-filters
 Filtering
 ---------
 
-Assuming that we have a SQLAlchemy `query` object:
+Assuming that we have a SQLAlchemy ``query`` object:
 
 .. code-block:: python
 
@@ -61,7 +61,8 @@ Then we can apply filters to that ``query`` object (multiple times):
 
     result = filtered_query.all()
 
-It is also possible to filter queries that contain multiple models, including joins:
+It is also possible to filter queries that contain multiple models,
+including joins:
 
 .. code-block:: python
 
@@ -84,7 +85,10 @@ It is also possible to filter queries that contain multiple models, including jo
     result = filtered_query.all()
 
 
-`apply_filters` will attempt to automatically join models to `query` if they're not already present and a model-specific filter is supplied. For example, the value of `filtered_query` in the following two code blocks is identical:
+``apply_filters`` will attempt to automatically join models to ``query``
+if they're not already present and a model-specific filter is supplied.
+For example, the value of ``filtered_query`` in the following two code
+blocks is identical:
 
 .. code-block:: python
 
@@ -106,11 +110,15 @@ It is also possible to filter queries that contain multiple models, including jo
     ]
     filtered_query = apply_filters(query, filter_spec)
 
-The automatic join is only possible if sqlalchemy can implictly determine the condition for the join, for example because of a foreign key relationship.
+The automatic join is only possible if sqlalchemy can implictly determine
+the condition for the join, for example because of a foreign key relationship.
 
-Automatic joins allow flexibility for clients to filter and sort by related objects without specifying all possible joins on the server beforehand.
+Automatic joins allow flexibility for clients to filter and sort by related
+objects without specifying all possible joins on the server beforehand.
 
-Note that first filter of the second block does not specify a model. It is implictly applied to the `Foo` model because that is the only model in the original query passed to `apply_filters`.
+Note that first filter of the second block does not specify a model.
+It is implictly applied to the ``Foo`` model because that is the only
+model in the original query passed to ``apply_filters``.
 
 It is also possible to apply filters to queries defined by fields or functions:
 
@@ -124,7 +132,7 @@ Restricted Loads
 ----------------
 
 You can restrict the fields that SQLAlchemy loads from the database by using
-the `apply_loads` function:
+the ``apply_loads`` function:
 
 .. code-block:: python
 
@@ -136,13 +144,18 @@ the `apply_loads` function:
     query = apply_loads(query, load_spec)  # will load only Foo.name and Bar.count
 
 
-The effect of the `apply_loads` function is to _defer_ the load of any other fields to when/if they're accessed, rather than loading them when the query is executed. It only applies to fields that would be loaded during normal query execution.
+The effect of the ``apply_loads`` function is to ``_defer_`` the load
+of any other fields to when/if they're accessed, rather than loading
+them when the query is executed. It only applies to fields that would be
+loaded during normal query execution.
 
 
 Effect on joined queries
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The default SQLAlchemy join is lazy, meaning that columns from the joined table are loaded only when required. Therefore `apply_loads` has limited effect in the following scenario:
+The default SQLAlchemy join is lazy, meaning that columns from the joined
+table are loaded only when required. Therefore ``apply_loads`` has limited
+effect in the following scenario:
 
 .. code-block:: python
 
@@ -154,7 +167,11 @@ The default SQLAlchemy join is lazy, meaning that columns from the joined table 
     query = apply_loads(query, load_spec)  # will load only Foo.name
 
 
-`apply_loads` cannot be applied to columns that are loaded as `joined eager loads <http://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html#joined-eager-loading>`_. This is because a joined eager load does not add the joined model to the original query, as explained `here <http://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html#the-zen-of-joined-eager-loading>`_
+``apply_loads`` cannot be applied to columns that are loaded as
+`joined eager loads <http://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html#joined-eager-loading>`_.
+This is because a joined eager load does not add the joined model to the
+original query, as explained
+`here <http://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html#the-zen-of-joined-eager-loading>`_
 
 The following would not prevent all columns from Bar being eagerly loaded:
 
@@ -169,10 +186,14 @@ The following would not prevent all columns from Bar being eagerly loaded:
 
 .. sidebar:: Automatic Join
 
-    In fact, what happens here is that `Bar` is automatically joined to `query`, because it is determined that `Bar` is not part of the original query. The `load_spec` therefore has no effect because the automatic join
-    results in lazy evaluation.
+    In fact, what happens here is that ``Bar`` is automatically joined
+    to ``query``, because it is determined that ``Bar`` is not part of
+    the original query. The ``load_spec`` therefore has no effect because
+    the automatic join results in lazy evaluation.
 
-If you wish to perform a joined load with restricted columns, you must specify the columns as part of the joined load, rather than with `apply_loads`:
+If you wish to perform a joined load with restricted columns, you must
+specify the columns as part of the joined load, rather than with
+``apply_loads``:
 
 .. code-block:: python
 
@@ -201,9 +222,12 @@ Sort
     result = sorted_query.all()
 
 
-`apply_sort` will attempt to automatically join models to `query` if they're not already present and a model-specific sort is supplied. The behaviour is the same as in `apply_filters`.
+``apply_sort`` will attempt to automatically join models to ``query`` if
+they're not already present and a model-specific sort is supplied.
+The behaviour is the same as in ``apply_filters``.
 
-This allows flexibility for clients to sort by fields on related objects without specifying all possible joins on the server beforehand.
+This allows flexibility for clients to sort by fields on related objects
+without specifying all possible joins on the server beforehand.
 
 
 Pagination
@@ -240,7 +264,8 @@ following format:
         # ...
     ]
 
-The `model` key is optional if the original query being filtered only applies to one model.
+The ``model`` key is optional if the original query being filtered only
+applies to one model.
 
 If there is only one filter, the containing list may be omitted:
 
@@ -249,7 +274,7 @@ If there is only one filter, the containing list may be omitted:
     filter_spec = {'field': 'field_name', 'op': '==', 'value': 'field_value'}
 
 Where ``field`` is the name of the field that will be filtered using the
-operator provided in ``op`` (optional, defaults to `==`) and the
+operator provided in ``op`` (optional, defaults to ``==``) and the
 provided ``value`` (optional, depending on the operator).
 
 This is the list of operators that can be used:
@@ -269,7 +294,8 @@ This is the list of operators that can be used:
 
 Boolean Functions
 ^^^^^^^^^^^^^^^^^
-``and``, ``or``, and ``not`` functions can be used and nested within the filter specification:
+``and``, ``or``, and ``not`` functions can be used and nested within the
+filter specification:
 
 .. code-block:: python
 
@@ -292,7 +318,8 @@ Boolean Functions
     ]
 
 
-Note: ``or`` and ``and`` must reference a list of at least one element. ``not`` must reference a list of exactly one element.
+Note: ``or`` and ``and`` must reference a list of at least one element.
+``not`` must reference a list of exactly one element.
 
 Sort format
 -----------
@@ -311,15 +338,16 @@ applied sequentially:
 Where ``field`` is the name of the field that will be sorted using the
 provided ``direction``.
 
-The `model` key is optional if the original query being sorted only applies to one model.
+The ``model`` key is optional if the original query being sorted only
+applies to one model.
 
 
 Running tests
 -------------
 
 The default configuration uses **SQLite**, **MySQL** (if the driver is
-installed, which is the case when `tox` is used) and **PostgreSQL** (if
-the driver is installed, which is the case when `tox` is used) to run
+installed, which is the case when ``tox`` is used) and **PostgreSQL** (if
+the driver is installed, which is the case when ``tox`` is used) to run
 the tests, with the following URIs:
 
 .. code-block:: shell

--- a/README.rst
+++ b/README.rst
@@ -317,19 +317,37 @@ The `model` key is optional if the original query being sorted only applies to o
 Running tests
 -------------
 
-There are some Makefile targets that can be used to run the tests. A
-test database will be created, used during the tests and destroyed
-afterwards.
-
-The default configuration uses both SQLite and MySQL (if the driver is
-installed) to run the tests, with the following URIs:
+The default configuration uses **SQLite**, **MySQL** (if the driver is
+installed, which is the case when `tox` is used) and **PostgreSQL** (if
+the driver is installed, which is the case when `tox` is used) to run
+the tests, with the following URIs:
 
 .. code-block:: shell
 
     sqlite+pysqlite:///test_sqlalchemy_filters.db
     mysql+mysqlconnector://root:@localhost:3306/test_sqlalchemy_filters
+    postgresql+psycopg2://postgres:@localhost:5432/test_sqlalchemy_filters?client_encoding=utf8'
 
-Example of usage:
+A test database will be created, used during the tests and destroyed
+afterwards for each RDMS configured.
+
+There are Makefile targets to run docker containers locally for both
+**MySQL** and **PostgreSQL**, using the default ports and configuration:
+
+.. code-block:: shell
+
+    $ make docker-mysql-run
+    $ make docker-postgres-run
+
+To run the tests locally:
+
+.. code-block:: shell
+
+    $ # Create/activate a virtual environment
+    $ pip install tox
+    $ tox
+
+There are some other Makefile targets that can be used to run the tests:
 
 .. code-block:: shell
 
@@ -343,6 +361,17 @@ Example of usage:
 
     $ ARGS='--mysql-test-db-uri mysql+mysqlconnector://root:@192.168.99.100:3340/test_sqlalchemy_filters' make coverage
     $ ARGS='--sqlite-test-db-uri sqlite+pysqlite:///test_sqlalchemy_filters.db' make coverage
+
+
+
+Database management systems
+---------------------------
+
+The following database management systems are supported (with test coverage):
+
+- SQLite
+- MySQL
+- PostgreSQL
 
 
 Python 2

--- a/README.rst
+++ b/README.rst
@@ -377,7 +377,7 @@ The following database management systems are supported (with test coverage):
 Python 2
 --------
 
-There is no active support for python 2, however it is compatiable as of February 2019, if you install `funcsigs`.
+There is no active support for python 2, however it is compatiable as of February 2019, if you install ``funcsigs``.
 
 
 License

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ setup(
         'mysql': [
             'mysql-connector-python-rf==2.2.2',
         ],
+        'postgresql': [
+            'psycopg2==2.7.7'
+        ],
         'python2': [
             "funcsigs>=1.0.2"
         ]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,6 +10,7 @@ from test.models import Base
 
 SQLITE_TEST_DB_URI = 'SQLITE_TEST_DB_URI'
 MYSQL_TEST_DB_URI = 'MYSQL_TEST_DB_URI'
+POSTGRESQL_TEST_DB_URI = 'POSTGRESQL_TEST_DB_URI'
 
 
 def pytest_addoption(parser):
@@ -39,12 +40,30 @@ def pytest_addoption(parser):
         )
     )
 
+    parser.addoption(
+        '--postgresql-test-db-uri',
+        action='store',
+        dest=POSTGRESQL_TEST_DB_URI,
+        default=(
+            'postgresql+psycopg2://postgres:@localhost:5432'
+            '/test_sqlalchemy_filters?client_encoding=utf8'
+        ),
+        help=(
+            'DB uri for testing (e.g. '
+            '"postgresql+psycopg2://username:password@localhost:5432'
+            '/test_sqlalchemy_filters?client_encoding=utf8")'
+        )
+    )
+
 
 @pytest.fixture(scope='session')
 def config(request):
     return {
         SQLITE_TEST_DB_URI: request.config.getoption(SQLITE_TEST_DB_URI),
         MYSQL_TEST_DB_URI: request.config.getoption(MYSQL_TEST_DB_URI),
+        POSTGRESQL_TEST_DB_URI: request.config.getoption(
+            POSTGRESQL_TEST_DB_URI
+        ),
     }
 
 
@@ -60,6 +79,13 @@ def test_db_keys():
     else:
         test_db_uris.append(MYSQL_TEST_DB_URI)
 
+    try:
+        import psycopg2  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        test_db_uris.append(POSTGRESQL_TEST_DB_URI)
+
     return test_db_uris
 
 
@@ -69,9 +95,17 @@ def db_uri(request, config):
 
 
 @pytest.fixture(scope='session')
-def connection(db_uri):
+def db_engine_options(db_uri):
+    return dict(
+        client_encoding='utf8',
+        connect_args={'client_encoding': 'utf8'}
+    )
+
+
+@pytest.fixture(scope='session')
+def connection(db_uri, db_engine_options):
     create_db(db_uri)
-    engine = create_engine(db_uri)
+    engine = create_engine(db_uri, **db_engine_options)
     Base.metadata.create_all(engine)
     connection = engine.connect()
     Base.metadata.bind = engine

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,8 +12,6 @@ SQLITE_TEST_DB_URI = 'SQLITE_TEST_DB_URI'
 MYSQL_TEST_DB_URI = 'MYSQL_TEST_DB_URI'
 POSTGRESQL_TEST_DB_URI = 'POSTGRESQL_TEST_DB_URI'
 
-POSTGRESQL_DB = 'postgresql'
-
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -98,7 +96,7 @@ def db_uri(request, config):
 
 @pytest.fixture(scope='session')
 def is_postgresql(db_uri):
-    if POSTGRESQL_DB in db_uri:
+    if 'postgresql' in db_uri:
         return True
     return False
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,6 +12,8 @@ SQLITE_TEST_DB_URI = 'SQLITE_TEST_DB_URI'
 MYSQL_TEST_DB_URI = 'MYSQL_TEST_DB_URI'
 POSTGRESQL_TEST_DB_URI = 'POSTGRESQL_TEST_DB_URI'
 
+POSTGRESQL_DB = 'postgresql'
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -96,10 +98,12 @@ def db_uri(request, config):
 
 @pytest.fixture(scope='session')
 def db_engine_options(db_uri):
-    return dict(
-        client_encoding='utf8',
-        connect_args={'client_encoding': 'utf8'}
-    )
+    if POSTGRESQL_DB in db_uri:
+        return dict(
+            client_encoding='utf8',
+            connect_args={'client_encoding': 'utf8'}
+        )
+    return {}
 
 
 @pytest.fixture(scope='session')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -97,8 +97,15 @@ def db_uri(request, config):
 
 
 @pytest.fixture(scope='session')
-def db_engine_options(db_uri):
+def is_postgresql(db_uri):
     if POSTGRESQL_DB in db_uri:
+        return True
+    return False
+
+
+@pytest.fixture(scope='session')
+def db_engine_options(db_uri, is_postgresql):
+    if is_postgresql:
         return dict(
             client_encoding='utf8',
             connect_args={'client_encoding': 'utf8'}

--- a/test/interface/test_sorting.py
+++ b/test/interface/test_sorting.py
@@ -108,12 +108,12 @@ class TestSortApplied(object):
     """Tests that the results are sorted according to the provided
     filters.
 
-    Do NOT test how any specific DBMS sorts the results for rows
+    Do NOT test how any specific RDBMS sorts the results for rows
     that have the same value in the field that is being sorted since
-    this is not consistent across DBMS.
+    this is not consistent across RDBMS.
 
     Also, sorting on fields with `None` values is NOT tested since
-    different DBMS behave differently when sorting `NULL` values. SQL
+    different RDBMS behave differently when sorting `NULL` values. SQL
     defines that `NULL` values should be placed together when sorting,
     but it does not specify whether they should be placed first or last
     in the result.

--- a/test/interface/test_sorting.py
+++ b/test/interface/test_sorting.py
@@ -105,18 +105,18 @@ class TestSortNotApplied(object):
 
 class TestSortApplied(object):
 
-    """Tests that the results are sorted according to the provided
+    """Tests that results are sorted only according to the provided
     filters.
 
-    Do NOT test how any specific RDBMS sorts the results for rows
-    that have the same value in the field that is being sorted since
-    this is not consistent across RDBMS.
+    Exclude nonexplicit sorting from tests: do NOT test how different
+    RDBMS sort rows with the same values being ordered since this is not
+    consistent across RDBMS.
 
-    Also, sorting on fields with `None` values is NOT tested since
-    different RDBMS behave differently when sorting `NULL` values. SQL
-    defines that `NULL` values should be placed together when sorting,
-    but it does not specify whether they should be placed first or last
-    in the result.
+    Exclude `NULL` sorting from tests: sorting fields containing `NULL`
+    values is NOT tested since different RDBMS behave differently when
+    sorting `NULL` values. SQL defines that `NULL` values should be
+    placed together when sorting, but it does not specify whether they
+    should be placed first or last in the result.
     """
 
     @pytest.mark.usefixtures('multiple_bars_with_no_nulls_inserted')
@@ -133,7 +133,6 @@ class TestSortApplied(object):
         result_same_name_4 = [result[5].id, result[6].id]
 
         assert len(result) == 8
-
         assert 1 in result_same_name_1
         assert 3 in result_same_name_1
         assert 5 in result_same_name_1
@@ -157,7 +156,6 @@ class TestSortApplied(object):
         ]
 
         assert len(result) == 8
-
         assert result[0].id == 8
         assert 4 in result_same_name_4
         assert 6 in result_same_name_4
@@ -250,7 +248,6 @@ class TestSortApplied(object):
         ]
 
         assert len(result) == 8
-
         assert result[0].id == 8
         assert 4 in result_same_name_4
         assert 6 in result_same_name_4

--- a/test/interface/test_sorting.py
+++ b/test/interface/test_sorting.py
@@ -108,11 +108,11 @@ class TestSortApplied(object):
     """Tests that results are sorted only according to the provided
     filters.
 
-    Exclude nonexplicit sorting from tests: do NOT test how different
+    Excludes nonexplicit sorting from tests: do NOT test how different
     RDBMS sort rows with the same values being ordered since this is not
     consistent across RDBMS.
 
-    Exclude `NULL` sorting from tests: sorting fields containing `NULL`
+    Excludes `NULL` sorting from tests: sorting fields containing `NULL`
     values is NOT tested since different RDBMS behave differently when
     sorting `NULL` values. SQL defines that `NULL` values should be
     placed together when sorting, but it does not specify whether they

--- a/test/interface/test_sorting.py
+++ b/test/interface/test_sorting.py
@@ -125,22 +125,14 @@ class TestSortApplied(object):
         order_by = [{'field': 'name', 'direction': 'asc'}]
 
         sorted_query = apply_sort(query, order_by)
-        result = sorted_query.all()
+        results = sorted_query.all()
 
-        results_with_same_order_1 = [
-            result[0].id, result[1].id, result[2].id, result[3].id
+        assert [result.name for result in results] == [
+            'name_1', 'name_1', 'name_1', 'name_1',
+            'name_2',
+            'name_4', 'name_4',
+            'name_5',
         ]
-        results_with_same_order_2 = [result[5].id, result[6].id]
-
-        assert len(result) == 8
-        assert 1 in results_with_same_order_1
-        assert 3 in results_with_same_order_1
-        assert 5 in results_with_same_order_1
-        assert 7 in results_with_same_order_1
-        assert result[4].id == 2
-        assert 4 in results_with_same_order_2
-        assert 6 in results_with_same_order_2
-        assert result[7].id == 8
 
     @pytest.mark.usefixtures('multiple_bars_with_no_nulls_inserted')
     def test_single_sort_field_desc(self, session):
@@ -148,22 +140,14 @@ class TestSortApplied(object):
         order_by = [{'field': 'name', 'direction': 'desc'}]
 
         sorted_query = apply_sort(query, order_by)
-        result = sorted_query.all()
+        results = sorted_query.all()
 
-        results_with_same_order_1 = [result[1].id, result[2].id]
-        results_with_same_order_2 = [
-            result[4].id, result[5].id, result[6].id, result[7].id
+        assert [result.name for result in results] == [
+            'name_5',
+            'name_4', 'name_4',
+            'name_2',
+            'name_1', 'name_1', 'name_1', 'name_1',
         ]
-
-        assert len(result) == 8
-        assert result[0].id == 8
-        assert 4 in results_with_same_order_1
-        assert 6 in results_with_same_order_1
-        assert result[3].id == 2
-        assert 1 in results_with_same_order_2
-        assert 3 in results_with_same_order_2
-        assert 5 in results_with_same_order_2
-        assert 7 in results_with_same_order_2
 
     @pytest.mark.usefixtures('multiple_bars_with_no_nulls_inserted')
     def test_multiple_sort_fields(self, session):
@@ -175,17 +159,17 @@ class TestSortApplied(object):
         ]
 
         sorted_query = apply_sort(query, order_by)
-        result = sorted_query.all()
+        results = sorted_query.all()
 
-        assert len(result) == 8
-        assert result[0].id == 1
-        assert result[1].id == 3
-        assert result[2].id == 7
-        assert result[3].id == 5
-        assert result[4].id == 2
-        assert result[5].id == 6
-        assert result[6].id == 4
-        assert result[7].id == 8
+        assert len(results) == 8
+        assert results[0].id == 1
+        assert results[1].id == 3
+        assert results[2].id == 7
+        assert results[3].id == 5
+        assert results[4].id == 2
+        assert results[5].id == 6
+        assert results[6].id == 4
+        assert results[7].id == 8
 
     def test_multiple_models(self, session):
 
@@ -226,13 +210,13 @@ class TestSortApplied(object):
         ]
 
         sorted_query = apply_sort(query, order_by)
-        result = sorted_query.all()
+        results = sorted_query.all()
 
-        assert len(result) == 4
-        assert result[0].id == 3
-        assert result[1].id == 1
-        assert result[2].id == 4
-        assert result[3].id == 2
+        assert len(results) == 4
+        assert results[0].id == 3
+        assert results[1].id == 1
+        assert results[2].id == 4
+        assert results[3].id == 2
 
     @pytest.mark.usefixtures('multiple_bars_with_no_nulls_inserted')
     def test_a_single_dict_can_be_supplied_as_sort_spec(self, session):
@@ -240,22 +224,14 @@ class TestSortApplied(object):
         sort_spec = {'field': 'name', 'direction': 'desc'}
 
         sorted_query = apply_sort(query, sort_spec)
-        result = sorted_query.all()
+        results = sorted_query.all()
 
-        results_with_same_order_1 = [result[1].id, result[2].id]
-        results_with_same_order_2 = [
-            result[4].id, result[5].id, result[6].id, result[7].id
+        assert [result.name for result in results] == [
+            'name_5',
+            'name_4', 'name_4',
+            'name_2',
+            'name_1', 'name_1', 'name_1', 'name_1',
         ]
-
-        assert len(result) == 8
-        assert result[0].id == 8
-        assert 4 in results_with_same_order_1
-        assert 6 in results_with_same_order_1
-        assert result[3].id == 2
-        assert 1 in results_with_same_order_2
-        assert 3 in results_with_same_order_2
-        assert 5 in results_with_same_order_2
-        assert 7 in results_with_same_order_2
 
 
 class TestAutoJoin:
@@ -271,17 +247,17 @@ class TestAutoJoin:
         ]
 
         sorted_query = apply_sort(query, order_by)
-        result = sorted_query.all()
+        results = sorted_query.all()
 
-        assert len(result) == 8
-        assert result[0].id == 5
-        assert result[1].id == 7
-        assert result[2].id == 6
-        assert result[3].id == 8
-        assert result[4].id == 1
-        assert result[5].id == 3
-        assert result[6].id == 2
-        assert result[7].id == 4
+        assert len(results) == 8
+        assert results[0].id == 5
+        assert results[1].id == 7
+        assert results[2].id == 6
+        assert results[3].id == 8
+        assert results[4].id == 1
+        assert results[5].id == 3
+        assert results[6].id == 2
+        assert results[7].id == 4
 
     @pytest.mark.usefixtures('multiple_foos_inserted')
     def test_noop_if_query_contains_named_models(self, session):
@@ -294,17 +270,17 @@ class TestAutoJoin:
         ]
 
         sorted_query = apply_sort(query, order_by)
-        result = sorted_query.all()
+        results = sorted_query.all()
 
-        assert len(result) == 8
-        assert result[0].id == 5
-        assert result[1].id == 7
-        assert result[2].id == 6
-        assert result[3].id == 8
-        assert result[4].id == 1
-        assert result[5].id == 3
-        assert result[6].id == 2
-        assert result[7].id == 4
+        assert len(results) == 8
+        assert results[0].id == 5
+        assert results[1].id == 7
+        assert results[2].id == 6
+        assert results[3].id == 8
+        assert results[4].id == 1
+        assert results[5].id == 3
+        assert results[6].id == 2
+        assert results[7].id == 4
 
     @pytest.mark.usefixtures('multiple_foos_inserted')
     def test_auto_join_to_invalid_model(self, session):
@@ -346,14 +322,14 @@ class TestAutoJoin:
         ]
 
         sorted_query = apply_sort(query, order_by)
-        result = sorted_query.all()
+        results = sorted_query.all()
 
-        assert len(result) == 8
-        assert result[0].id == 5
-        assert result[1].id == 7
-        assert result[2].id == 6
-        assert result[3].id == 8
-        assert result[4].id == 1
-        assert result[5].id == 3
-        assert result[6].id == 2
-        assert result[7].id == 4
+        assert len(results) == 8
+        assert results[0].id == 5
+        assert results[1].id == 7
+        assert results[2].id == 6
+        assert results[3].id == 8
+        assert results[4].id == 1
+        assert results[5].id == 3
+        assert results[6].id == 2
+        assert results[7].id == 4

--- a/test/interface/test_sorting.py
+++ b/test/interface/test_sorting.py
@@ -127,19 +127,19 @@ class TestSortApplied(object):
         sorted_query = apply_sort(query, order_by)
         result = sorted_query.all()
 
-        result_same_name_1 = [
+        results_with_same_order_1 = [
             result[0].id, result[1].id, result[2].id, result[3].id
         ]
-        result_same_name_4 = [result[5].id, result[6].id]
+        results_with_same_order_2 = [result[5].id, result[6].id]
 
         assert len(result) == 8
-        assert 1 in result_same_name_1
-        assert 3 in result_same_name_1
-        assert 5 in result_same_name_1
-        assert 7 in result_same_name_1
+        assert 1 in results_with_same_order_1
+        assert 3 in results_with_same_order_1
+        assert 5 in results_with_same_order_1
+        assert 7 in results_with_same_order_1
         assert result[4].id == 2
-        assert 4 in result_same_name_4
-        assert 6 in result_same_name_4
+        assert 4 in results_with_same_order_2
+        assert 6 in results_with_same_order_2
         assert result[7].id == 8
 
     @pytest.mark.usefixtures('multiple_bars_with_no_nulls_inserted')
@@ -150,20 +150,20 @@ class TestSortApplied(object):
         sorted_query = apply_sort(query, order_by)
         result = sorted_query.all()
 
-        result_same_name_4 = [result[1].id, result[2].id]
-        result_same_name_1 = [
+        results_with_same_order_1 = [result[1].id, result[2].id]
+        results_with_same_order_2 = [
             result[4].id, result[5].id, result[6].id, result[7].id
         ]
 
         assert len(result) == 8
         assert result[0].id == 8
-        assert 4 in result_same_name_4
-        assert 6 in result_same_name_4
+        assert 4 in results_with_same_order_1
+        assert 6 in results_with_same_order_1
         assert result[3].id == 2
-        assert 1 in result_same_name_1
-        assert 3 in result_same_name_1
-        assert 5 in result_same_name_1
-        assert 7 in result_same_name_1
+        assert 1 in results_with_same_order_2
+        assert 3 in results_with_same_order_2
+        assert 5 in results_with_same_order_2
+        assert 7 in results_with_same_order_2
 
     @pytest.mark.usefixtures('multiple_bars_with_no_nulls_inserted')
     def test_multiple_sort_fields(self, session):
@@ -242,20 +242,20 @@ class TestSortApplied(object):
         sorted_query = apply_sort(query, sort_spec)
         result = sorted_query.all()
 
-        result_same_name_4 = [result[1].id, result[2].id]
-        result_same_name_1 = [
+        results_with_same_order_1 = [result[1].id, result[2].id]
+        results_with_same_order_2 = [
             result[4].id, result[5].id, result[6].id, result[7].id
         ]
 
         assert len(result) == 8
         assert result[0].id == 8
-        assert 4 in result_same_name_4
-        assert 6 in result_same_name_4
+        assert 4 in results_with_same_order_1
+        assert 6 in results_with_same_order_1
         assert result[3].id == 2
-        assert 1 in result_same_name_1
-        assert 3 in result_same_name_1
-        assert 5 in result_same_name_1
-        assert 7 in result_same_name_1
+        assert 1 in results_with_same_order_2
+        assert 3 in results_with_same_order_2
+        assert 5 in results_with_same_order_2
+        assert 7 in results_with_same_order_2
 
 
 class TestAutoJoin:

--- a/test/interface/test_sorting.py
+++ b/test/interface/test_sorting.py
@@ -108,15 +108,15 @@ class TestSortApplied(object):
     """Tests that results are sorted only according to the provided
     filters.
 
-    Excludes nonexplicit sorting from tests: do NOT test how different
-    RDBMS sort rows with the same values being ordered since this is not
-    consistent across RDBMS.
+    Does NOT test how rows with the same values are sorted since this is
+    not consistent across RDBMS.
 
-    Excludes `NULL` sorting from tests: sorting fields containing `NULL`
-    values is NOT tested since different RDBMS behave differently when
-    sorting `NULL` values. SQL defines that `NULL` values should be
-    placed together when sorting, but it does not specify whether they
-    should be placed first or last in the result.
+    Does NOT test whether `NULL` field values are placed first or last
+    when sorting since this may differ across RDBMSs.
+
+    SQL defines that `NULL` values should be placed together when
+    sorting, but it does not specify whether they should be placed first
+    or last.
     """
 
     @pytest.mark.usefixtures('multiple_bars_with_no_nulls_inserted')

--- a/test/interface/test_sorting.py
+++ b/test/interface/test_sorting.py
@@ -110,7 +110,7 @@ class TestSortApplied(object):
 
     Do NOT test how any specific DBMS sorts the results for rows
     that have the same value in the field that is being sorted since
-    this is not consistent accross DBMS.
+    this is not consistent across DBMS.
 
     Also, sorting on fields with `None` values is NOT tested since
     different DBMS behave differently when sorting `NULL` values. SQL

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ usedevelop = true
 extras =
     dev
     mysql
+    postgresql
 deps =
     py27: funcsigs
 commands =


### PR DESCRIPTION
* Travis CI:
  * Use Ubuntu `xenial`
  * Use Python 3.7
  * Start PostgreSQL `9.6` service (PostgreSQL pre-installed versions: `9.4.20`, `9.5.15`, `9.6.11`)
* Install `psycopg2` as part of the `postgresql` extras to run the tests
* Run the tests also using PostgreSQL:
  * Improve sorting tests: assert based on the fields being sorted
  * Test that results are sorted *only* according to the provided filters.
  * Do ***not*** test how rows with the same values are sorted since this is not consistent across RDBMS.
  * Do ***not*** test whether `NULL` field values are placed first or last when sorting since this may differ across RDBMSs.
    * SQL defines that `NULL` values should be placed together when sorting, but it does not specify whether they should be placed first or last in the result.
    * (I'm currently preparing another PR to implement `nullsfirst` and `nullslast`).
* Add Makefile targets to run MySQL and PostgreSQL Docker containers for testing.
* Amend/improve README documentation:
  * Fix inline literals
  * Make line sizes consistent
  * Mention all the RDBMS that are tested
  * Improve the testing section
* Fix CHANGELOG syntax.