### PR TITLE
Add multiple SQLAlchemy versions support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: python
 python: 3.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ services:
   - docker
 
 before_install:
-  - make docker-mysql-run
-  - make docker-postgres-run
+  - make mysql-container
+  - make postgres-container
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,17 +29,6 @@ matrix:
     - python: 2.7
       env: TOX_ENV="py27-sqlalchemylatest"
 
-    - python: 3.4
-      env: TOX_ENV="py34-sqlalchemy1.0"
-    - python: 3.4
-      env: TOX_ENV="py34-sqlalchemy1.1"
-    - python: 3.4
-      env: TOX_ENV="py34-sqlalchemy1.2"
-    - python: 3.4
-      env: TOX_ENV="py34-sqlalchemy1.3"
-    - python: 3.4
-      env: TOX_ENV="py34-sqlalchemylatest"
-
     - python: 3.5
       env: TOX_ENV="py35-sqlalchemy1.0"
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,23 +19,59 @@ matrix:
   include:
     - stage: test
       python: 2.7
-      env: TOX_ENV=py27
+      env: TOX_ENV="py27-sqlalchemy1.0"
+    - python: 2.7
+      env: TOX_ENV="py27-sqlalchemy1.1"
+    - python: 2.7
+      env: TOX_ENV="py27-sqlalchemy1.2"
+    - python: 2.7
+      env: TOX_ENV="py27-sqlalchemy1.3"
+    - python: 2.7
+      env: TOX_ENV="py27-sqlalchemylatest"
 
-    - stage: test
-      python: 3.4
-      env: TOX_ENV=py34
+    - python: 3.4
+      env: TOX_ENV="py34-sqlalchemy1.0"
+    - python: 3.4
+      env: TOX_ENV="py34-sqlalchemy1.1"
+    - python: 3.4
+      env: TOX_ENV="py34-sqlalchemy1.2"
+    - python: 3.4
+      env: TOX_ENV="py34-sqlalchemy1.3"
+    - python: 3.4
+      env: TOX_ENV="py34-sqlalchemylatest"
 
-    - stage: test
-      python: 3.5
-      env: TOX_ENV=py35
+    - python: 3.5
+      env: TOX_ENV="py35-sqlalchemy1.0"
+    - python: 3.5
+      env: TOX_ENV="py35-sqlalchemy1.1"
+    - python: 3.5
+      env: TOX_ENV="py35-sqlalchemy1.2"
+    - python: 3.5
+      env: TOX_ENV="py35-sqlalchemy1.3"
+    - python: 3.5
+      env: TOX_ENV="py35-sqlalchemylatest"
 
-    - stage: test
-      python: 3.6
-      env: TOX_ENV=py36
+    - python: 3.6
+      env: TOX_ENV="py36-sqlalchemy1.0"
+    - python: 3.6
+      env: TOX_ENV="py36-sqlalchemy1.1"
+    - python: 3.6
+      env: TOX_ENV="py36-sqlalchemy1.2"
+    - python: 3.6
+      env: TOX_ENV="py36-sqlalchemy1.3"
+    - python: 3.6
+      env: TOX_ENV="py36-sqlalchemylatest"
 
-    - stage: test
-      python: 3.7
-      env: TOX_ENV=py37
+    - python: 3.7
+      env: TOX_ENV="py37-sqlalchemy1.0"
+    - python: 3.7
+      env: TOX_ENV="py37-sqlalchemy1.1"
+    - python: 3.7
+      env: TOX_ENV="py37-sqlalchemy1.2"
+    - python: 3.7
+      env: TOX_ENV="py37-sqlalchemy1.3"
+    - python: 3.7
+      env: TOX_ENV="py37-sqlalchemylatest"
 
     - stage: deploy
       script: skip

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ coverage: flake8 rst-lint
 
 # Docker test containers
 
-docker-mysql-run:
+mysql-container:
 	docker run -d --rm --name mysql-sqlalchemy-filters -p 3306:3306 \
 		-e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
 		mysql:$(MYSQL_VERSION)
 
-docker-postgres-run:
+postgres-container:
 	docker run -d --rm --name postgres-sqlalchemy-filters -p 5432:5432 \
 		-e POSTGRES_USER=postgres \
 		-e POSTGRES_PASSWORD= \

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,14 @@ rst-lint:
 	rst-lint CHANGELOG.rst
 
 flake8:
-	flake8 sqlalchemy_filters test
+	flake8 sqlalchemy_filters test setup.py
 
 test: flake8
 	pytest test $(ARGS)
 
 coverage: flake8 rst-lint
 	coverage run --source sqlalchemy_filters -m pytest test $(ARGS)
-	coverage report -m --fail-under 100
+	coverage report --show-missing --fail-under 100
 
 
 # Docker test containers

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ SQLAlchemy filters
 
 .. pull-quote::
 
-    Filter, sort and paginate SQLAlchemy query objects.
+    Filter, sort and paginate SQLAlchemy_ query objects.
     Ideal for exposing these actions over a REST API.
 
 
@@ -23,7 +23,7 @@ SQLAlchemy filters
 Filtering
 ---------
 
-Assuming that we have a SQLAlchemy ``query`` object:
+Assuming that we have a SQLAlchemy_ ``query`` object:
 
 .. code-block:: python
 
@@ -113,7 +113,7 @@ blocks is identical:
     ]
     filtered_query = apply_filters(query, filter_spec)
 
-The automatic join is only possible if sqlalchemy can implictly
+The automatic join is only possible if SQLAlchemy_ can implictly
 determine the condition for the join, for example because of a foreign
 key relationship.
 
@@ -137,7 +137,7 @@ functions:
 Restricted Loads
 ----------------
 
-You can restrict the fields that SQLAlchemy loads from the database by
+You can restrict the fields that SQLAlchemy_ loads from the database by
 using the ``apply_loads`` function:
 
 .. code-block:: python
@@ -159,7 +159,7 @@ loaded during normal query execution.
 Effect on joined queries
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The default SQLAlchemy join is lazy, meaning that columns from the
+The default SQLAlchemy_ join is lazy, meaning that columns from the
 joined table are loaded only when required. Therefore ``apply_loads``
 has limited effect in the following scenario:
 
@@ -370,7 +370,7 @@ to the RDBMS being used. SQL defines that ``NULL`` values should be placed
 together when sorting, but it does not specify whether they should be placed
 first or last.
 
-Even though both ``nullsfirst`` and ``nullslast`` are part of SQLAlchemy,
+Even though both ``nullsfirst`` and ``nullslast`` are part of SQLAlchemy_,
 they will raise an unexpected exception if the RDBMS that is being used does
 not support them.
 
@@ -447,6 +447,13 @@ There is no active support for python 2, however it is compatible as of
 February 2019, if you install ``funcsigs``.
 
 
+SQLAlchemy support
+------------------
+
+The following SQLAlchemy_ versions are supported: ``1.0``, ``1.1``,
+``1.2``, ``1.3``.
+
+
 Changelog
 ---------
 
@@ -459,3 +466,6 @@ License
 
 Apache 2.0. See `LICENSE <https://github.com/juliotrigo/sqlalchemy-filters/blob/master/LICENSE>`_
 for details.
+
+
+.. _SQLAlchemy: https://www.sqlalchemy.org/

--- a/README.rst
+++ b/README.rst
@@ -402,8 +402,8 @@ There are Makefile targets to run docker containers locally for both
 
 .. code-block:: shell
 
-    $ make docker-mysql-run
-    $ make docker-postgres-run
+    $ make mysql-container
+    $ make postgres-container
 
 To run the tests locally:
 

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@ SQLAlchemy filters
 
 .. pull-quote::
 
-    Filter, sort and paginate SQLAlchemy_ query objects.
-    Ideal for exposing these actions over a REST API.
+    Filter, sort and paginate SQLAlchemy query objects. Ideal for
+    exposing these actions over a REST API.
 
 
 .. image:: https://img.shields.io/pypi/v/sqlalchemy-filters.svg

--- a/README.rst
+++ b/README.rst
@@ -452,7 +452,7 @@ Python 2
 --------
 
 There is no active support for Python 2. However, it is compatible as of
-February 2019, if you install ``funcsigs``, included in the `python2`
+February 2019, if you install ``funcsigs``, included in the ``python2``
 extra requirements.
 
 

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,7 @@ Then we can apply filters to that ``query`` object (multiple times):
 
     from sqlalchemy_filters import apply_filters
 
+
     # `query` should be a SQLAlchemy query object
 
     filter_spec = [{'field': 'name', 'op': '==', 'value': 'name_1'}]
@@ -72,6 +73,7 @@ including joins:
     class Bar(Base):
 
         __tablename__ = 'bar'
+
         foo_id = Column(Integer, ForeignKey('foo.id'))
 
 
@@ -218,6 +220,7 @@ Sort
 
     from sqlalchemy_filters import apply_sort
 
+
     # `query` should be a SQLAlchemy query object
 
     sort_spec = [
@@ -243,6 +246,7 @@ Pagination
 .. code-block:: python
 
     from sqlalchemy_filters import apply_pagination
+
 
     # `query` should be a SQLAlchemy query object
 
@@ -415,8 +419,12 @@ To run the tests locally:
 
 There are some other Makefile targets that can be used to run the tests:
 
+There are other Makefile targets to run the tests, but extra
+dependencies will have to be installed:
+
 .. code-block:: shell
 
+    $ pip install -U --editable ".[dev,mysql,postgresql]"
     $ # using default settings
     $ make test
     $ make coverage
@@ -443,8 +451,9 @@ The following RDBMS are supported (tested):
 Python 2
 --------
 
-There is no active support for python 2, however it is compatible as of
-February 2019, if you install ``funcsigs``.
+There is no active support for Python 2. However, it is compatible as of
+February 2019, if you install ``funcsigs``, included in the `python2`
+extra requirements.
 
 
 SQLAlchemy support

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -26,18 +26,18 @@ setup(
     ],
     extras_require={
         'dev': [
-            'pytest==4.3.0',
-            'flake8==3.7.7',
+            'pytest==4.4.0',
             'coverage==4.5.3',
             'sqlalchemy-utils==0.33.11',
-            'restructuredtext-lint==1.2.2',
+            'flake8==3.7.7',
+            'restructuredtext-lint==1.3.0',
             'Pygments==2.3.1',
         ],
         'mysql': [
             'mysql-connector-python-rf==2.2.2',
         ],
         'postgresql': [
-            'psycopg2==2.7.7'
+            'psycopg2==2.8.1'
         ],
         'python2': [
             "funcsigs>=1.0.2"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36,py37}-sqlalchemy{1.0,1.1,1.2,1.3,latest}
+envlist = {py27,py35,py36,py37}-sqlalchemy{1.0,1.1,1.2,1.3,latest}
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27, py34, py35, py36, py37}
+envlist = {py27,py34,py35,py36,py37}-sqlalchemy{1.0,1.1,1.2,1.3,latest}
 skipsdist = True
 
 [testenv]
@@ -11,5 +11,9 @@ extras =
     postgresql
 deps =
     py27: funcsigs
+    sqlalchemy1.0: sqlalchemy>=1.0,<1.1
+    sqlalchemy1.1: sqlalchemy>=1.1,<1.2
+    sqlalchemy1.2: sqlalchemy>=1.2,<1.3
+    sqlalchemy1.3: sqlalchemy>=1.3,<1.4
 commands =
     make coverage ARGS='-x -vv'


### PR DESCRIPTION
* Add multiple SQLAlchemy versions support
  * Ensure tests pass with the SQLAlchemy versions that we're supposed to be compatible with
  * Actively support the latest version of each minor release (`1.0.x`, `1.1.x`...) until we decide to stop testing some old versions
  * Always test the latest SQLAlchemy release (using `latest`)
* Remove Python 3.4 support.
* Improve Makefile and Travis CI scripts
* Improve `README` documentation
* Upgrade extra Python requirements