### PR TITLE
Account select_from(model) to query models

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,13 +128,14 @@ Note that first filter of the second block does not specify a model.
 It is implictly applied to the ``Foo`` model because that is the only
 model in the original query passed to ``apply_filters``.
 
-It is also possible to apply filters to queries defined by fields or
-functions:
+It is also possible to apply filters to queries defined by fields, functions or
+``select_from`` clause:
 
 .. code-block:: python
 
     query_alt_1 = session.query(Foo.id, Foo.name)
     query_alt_2 = session.query(func.count(Foo.id))
+    query_alt_3 = session.query().select_from(Foo).add_column(Foo.id)
 
 
 Restricted Loads

--- a/sqlalchemy_filters/models.py
+++ b/sqlalchemy_filters/models.py
@@ -1,5 +1,6 @@
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.inspection import inspect
+from sqlalchemy.orm.mapper import Mapper
 
 from .exceptions import BadQuery, FieldNotFound, BadSpec
 
@@ -31,6 +32,20 @@ def get_query_models(query):
     """
     models = [col_desc['entity'] for col_desc in query.column_descriptions]
     models.extend(mapper.class_ for mapper in query._join_entities)
+
+    # account also query.select_from entities
+    if (
+        hasattr(query, '_select_from_entity') and
+        (query._select_from_entity is not None)
+    ):
+        model_class = (
+            query._select_from_entity.class_
+            if isinstance(query._select_from_entity, Mapper)  # sqlalchemy>=1.1
+            else query._select_from_entity  # sqlalchemy==1.0
+        )
+        if model_class not in models:
+            models.append(model_class)
+
     return {model.__name__: model for model in models}
 
 

--- a/test/interface/test_models.py
+++ b/test/interface/test_models.py
@@ -26,6 +26,13 @@ class TestGetQueryModels(object):
 
         assert {'Bar': Bar} == entities
 
+    def test_query_with_select_from_model(self, session):
+        query = session.query().select_from(Bar)
+
+        entities = get_query_models(query)
+
+        assert {'Bar': Bar} == entities
+
     def test_query_with_multiple_models(self, session):
         query = session.query(Bar, Qux)
 


### PR DESCRIPTION
When used with https://github.com/Pegase745/sqlalchemy-datatables/ the query is constructed with .select_from(). This PR adds ability to account entity added to query. Note that patch works on all sqla versions, but coverage had to be tuned by pragma to pass 100% constraint.