### PR TITLE
Add argument to disable autojoin on demand.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,9 +119,10 @@ The automatic join is only possible if SQLAlchemy_ can implictly
 determine the condition for the join, for example because of a foreign
 key relationship.
 
-Automatic joins allow flexibility for clients to filter and sort by
-related objects without specifying all possible joins on the server
-beforehand.
+Automatic joins allow flexibility for clients to filter and sort by related
+objects without specifying all possible joins on the server beforehand. Feature
+can be explicitly disabled by passing ``do_auto_join=False`` argument to the
+``apply_filters`` call.
 
 Note that first filter of the second block does not specify a model.
 It is implictly applied to the ``Foo`` model because that is the only

--- a/sqlalchemy_filters/filters.py
+++ b/sqlalchemy_filters/filters.py
@@ -187,7 +187,7 @@ def get_named_models(filters):
     return models
 
 
-def apply_filters(query, filter_spec):
+def apply_filters(query, filter_spec, do_auto_join=True):
     """Apply filters to a SQLAlchemy query.
 
     :param query:
@@ -227,7 +227,8 @@ def apply_filters(query, filter_spec):
     default_model = get_default_model(query)
 
     filter_models = get_named_models(filters)
-    query = auto_join(query, *filter_models)
+    if do_auto_join:
+        query = auto_join(query, *filter_models)
 
     sqlalchemy_filters = [
         filter.format_for_sqlalchemy(query, default_model)

--- a/test/interface/test_filters.py
+++ b/test/interface/test_filters.py
@@ -200,6 +200,20 @@ class TestAutoJoin:
         assert result[0].bar.count is None
 
     @pytest.mark.usefixtures('multiple_foos_inserted')
+    def test_do_not_auto_join(self, session):
+
+        query = session.query(Foo)
+        filters = [
+            {'field': 'name', 'op': '==', 'value': 'name_1'},
+            {'model': 'Bar', 'field': 'count', 'op': 'is_null'},
+        ]
+
+        with pytest.raises(BadSpec) as exc:
+            apply_filters(query, filters, do_auto_join=False)
+
+        assert 'The query does not contain model `Bar`' in str(exc)
+
+    @pytest.mark.usefixtures('multiple_foos_inserted')
     def test_noop_if_query_contains_named_models(self, session):
 
         query = session.query(Foo).join(Bar)


### PR DESCRIPTION
When passing filters parsed from client request it might be desirable to disable auto join feature on demand. Please consider the simple patch.