### PR TITLE
Add support for sqlalchemy any operator to query arrays

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -305,6 +305,14 @@ This is the list of operators that can be used:
 - ``not_ilike``
 - ``in``
 - ``not_in``
+- ``any``
+- ``not_any``
+
+any / not_any
+^^^^^^^^^^^^^
+
+PostgreSQL specific operators allow to filter queries on columns of type ``ARRAY``.
+Use ``any`` to filter if a value is present in an array and ``not_any`` if it's not.
 
 Boolean Functions
 ^^^^^^^^^^^^^^^^^

--- a/sqlalchemy_filters/filters.py
+++ b/sqlalchemy_filters/filters.py
@@ -15,7 +15,7 @@ except ImportError:  # pragma: no cover
 from itertools import chain
 
 from six import string_types
-from sqlalchemy import and_, or_, not_
+from sqlalchemy import and_, or_, not_, func
 
 from .exceptions import BadFilterFormat
 from .models import Field, auto_join, get_model_from_spec, get_default_model
@@ -56,6 +56,8 @@ class Operator(object):
         'not_ilike': lambda f, a: ~f.ilike(a),
         'in': lambda f, a: f.in_(a),
         'not_in': lambda f, a: ~f.in_(a),
+        'any': lambda f, a: f.any(a),
+        'not_any': lambda f, a: func.not_(f.any(a)),
     }
 
     def __init__(self, operator=None):

--- a/test/models.py
+++ b/test/models.py
@@ -3,6 +3,7 @@
 from sqlalchemy import (
     Column, Date, DateTime, ForeignKey, Integer, String, Time
 )
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 
@@ -14,6 +15,7 @@ class Base(object):
 
 
 Base = declarative_base(cls=Base)
+BasePostgresqlSpecific = declarative_base(cls=Base)
 
 
 class Foo(Base):
@@ -44,3 +46,10 @@ class Qux(Base):
     created_at = Column(Date)
     execution_time = Column(DateTime)
     expiration_time = Column(Time)
+
+
+class Corge(BasePostgresqlSpecific):
+
+    __tablename__ = 'corge'
+
+    tags = Column(ARRAY(String, dimensions=1))


### PR DESCRIPTION
Add support for sqlalchemy any operator to query arrays. "any" filter models having value in attribute of array type, "not_all" filter models not having value in attribute of array. Adds postgresql specific tests/models for querying arrays.