### PR TITLE
Support json_contains in JSON field

### DIFF
--- a/sqlalchemy_filters/filters.py
+++ b/sqlalchemy_filters/filters.py
@@ -58,6 +58,9 @@ class Operator(object):
         'not_in': lambda f, a: ~f.in_(a),
         'any': lambda f, a: f.any(a),
         'not_any': lambda f, a: func.not_(f.any(a)),
+        'json_contains': lambda f, a: func.json_contains(
+            f, func.json_array(a)
+        ),
     }
 
     def __init__(self, operator=None):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -110,12 +110,11 @@ def is_sqlite(db_uri):
 
 @pytest.fixture(scope='session')
 def is_sqlalchemy_1_3_or_higer():
-    try:
-        from sqlalchemy import JSON  # noqa: F401
-    except ImportError:
-        return False
-    else:
+    import sqlalchemy
+    if sqlalchemy.__version__ >= '1.3.0':
         return True
+    else:
+        return False
 
 
 @pytest.fixture(scope='session')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -109,6 +109,16 @@ def is_sqlite(db_uri):
 
 
 @pytest.fixture(scope='session')
+def is_sqlalchemy_1_3_or_higer():
+    try:
+        from sqlalchemy import JSON  # noqa: F401
+    except ImportError:
+        return False
+    else:
+        return True
+
+
+@pytest.fixture(scope='session')
 def db_engine_options(db_uri, is_postgresql):
     if is_postgresql:
         return dict(

--- a/test/interface/test_filters.py
+++ b/test/interface/test_filters.py
@@ -1331,8 +1331,11 @@ class TestHybridAttributes:
 class TestApplyJsonContainsFilter:
 
     @pytest.mark.usefixtures('multiple_tils_inserted')
-    def test_til_not_contains_value(self, session, is_sqlite):
+    def test_til_not_contains_value(self, session, is_sqlite, is_postgresql):
         if is_sqlite:
+            pytest.skip()
+
+        if is_postgresql:
             pytest.skip()
 
         query = session.query(Til)
@@ -1346,8 +1349,11 @@ class TestApplyJsonContainsFilter:
         assert len(result) == 0
 
     @pytest.mark.usefixtures('multiple_tils_inserted')
-    def test_til_contains_int_value(self, session, is_sqlite):
+    def test_til_contains_int_value(self, session, is_sqlite, is_postgresql):
         if is_sqlite:
+            pytest.skip()
+
+        if is_postgresql:
             pytest.skip()
 
         query = session.query(Til)
@@ -1362,8 +1368,11 @@ class TestApplyJsonContainsFilter:
         assert result[0].id == 2
 
     @pytest.mark.usefixtures('multiple_tils_inserted')
-    def test_til_contains_str_value(self, session, is_sqlite):
+    def test_til_contains_str_value(self, session, is_sqlite, is_postgresql):
         if is_sqlite:
+            pytest.skip()
+
+        if is_postgresql:
             pytest.skip()
 
         query = session.query(Til)

--- a/test/interface/test_filters.py
+++ b/test/interface/test_filters.py
@@ -12,7 +12,7 @@ from sqlalchemy_filters.exceptions import (
     BadFilterFormat, BadSpec, FieldNotFound
 )
 
-from test.models import Foo, Bar, Qux, Corge
+from test.models import Foo, Bar, Qux, Corge, Til
 
 
 ARRAY_NOT_SUPPORTED = (
@@ -83,6 +83,16 @@ def multiple_corges_inserted(session, is_postgresql):
         corge_4 = Corge(id=4, name='name_4', tags=['bar', 'baz'])
         session.add_all([corge_1, corge_2, corge_3, corge_4])
         session.commit()
+
+
+@pytest.fixture
+def multiple_tils_inserted(session):
+    til_1 = Til(id=1, name='name_1', refer_info=[])
+    til_2 = Til(id=2, name='name_2', refer_info=[1])
+    til_3 = Til(id=3, name='name_3', refer_info=[2, 3])
+    til_4 = Til(id=4, name='name_4', refer_info=['foo', 'baz'])
+    session.add_all([til_1, til_2, til_3, til_4])
+    session.commit()
 
 
 class TestFiltersNotApplied:
@@ -1316,3 +1326,53 @@ class TestHybridAttributes:
         assert set(map(type, quxs)) == {Qux}
         assert {qux.id for qux in quxs} == {4}
         assert {qux.three_times_count() for qux in quxs} == {45}
+
+
+class TestApplyJsonContainsFilter:
+
+    @pytest.mark.usefixtures('multiple_tils_inserted')
+    def test_til_not_contains_value(self, session, is_sqlite):
+        if is_sqlite:
+            pytest.skip()
+
+        query = session.query(Til)
+        filters = [
+            {'field': 'refer_info', 'op': 'json_contains', 'value': 'invalid'}
+        ]
+
+        filtered_query = apply_filters(query, filters)
+        result = filtered_query.all()
+
+        assert len(result) == 0
+
+    @pytest.mark.usefixtures('multiple_tils_inserted')
+    def test_til_contains_int_value(self, session, is_sqlite):
+        if is_sqlite:
+            pytest.skip()
+
+        query = session.query(Til)
+        filters = [
+            {'field': 'refer_info', 'op': 'json_contains', 'value': 1}
+        ]
+
+        filtered_query = apply_filters(query, filters)
+        result = filtered_query.all()
+
+        assert len(result) == 1
+        assert result[0].id == 2
+
+    @pytest.mark.usefixtures('multiple_tils_inserted')
+    def test_til_contains_str_value(self, session, is_sqlite):
+        if is_sqlite:
+            pytest.skip()
+
+        query = session.query(Til)
+        filters = [
+            {'field': 'refer_info', 'op': 'json_contains', 'value': "foo"}
+        ]
+
+        filtered_query = apply_filters(query, filters)
+        result = filtered_query.all()
+
+        assert len(result) == 1
+        assert result[0].id == 4

--- a/test/interface/test_filters.py
+++ b/test/interface/test_filters.py
@@ -86,13 +86,15 @@ def multiple_corges_inserted(session, is_postgresql):
 
 
 @pytest.fixture
-def multiple_tils_inserted(session):
-    til_1 = Til(id=1, name='name_1', refer_info=[])
-    til_2 = Til(id=2, name='name_2', refer_info=[1])
-    til_3 = Til(id=3, name='name_3', refer_info=[2, 3])
-    til_4 = Til(id=4, name='name_4', refer_info=['foo', 'baz'])
-    session.add_all([til_1, til_2, til_3, til_4])
-    session.commit()
+def multiple_tils_inserted(session, is_sqlalchemy_1_3_or_higer):
+    if is_sqlalchemy_1_3_or_higer:
+
+        til_1 = Til(id=1, name='name_1', refer_info=[])
+        til_2 = Til(id=2, name='name_2', refer_info=[1])
+        til_3 = Til(id=3, name='name_3', refer_info=[2, 3])
+        til_4 = Til(id=4, name='name_4', refer_info=['foo', 'baz'])
+        session.add_all([til_1, til_2, til_3, til_4])
+        session.commit()
 
 
 class TestFiltersNotApplied:
@@ -1331,11 +1333,16 @@ class TestHybridAttributes:
 class TestApplyJsonContainsFilter:
 
     @pytest.mark.usefixtures('multiple_tils_inserted')
-    def test_til_not_contains_value(self, session, is_sqlite, is_postgresql):
+    def test_til_not_contains_value(
+        self, session, is_sqlite, is_postgresql, is_sqlalchemy_1_3_or_higer
+    ):
         if is_sqlite:
             pytest.skip()
 
         if is_postgresql:
+            pytest.skip()
+
+        if not is_sqlalchemy_1_3_or_higer:
             pytest.skip()
 
         query = session.query(Til)
@@ -1349,11 +1356,16 @@ class TestApplyJsonContainsFilter:
         assert len(result) == 0
 
     @pytest.mark.usefixtures('multiple_tils_inserted')
-    def test_til_contains_int_value(self, session, is_sqlite, is_postgresql):
+    def test_til_contains_int_value(
+        self, session, is_sqlite, is_postgresql, is_sqlalchemy_1_3_or_higer
+    ):
         if is_sqlite:
             pytest.skip()
 
         if is_postgresql:
+            pytest.skip()
+
+        if not is_sqlalchemy_1_3_or_higer:
             pytest.skip()
 
         query = session.query(Til)
@@ -1368,11 +1380,16 @@ class TestApplyJsonContainsFilter:
         assert result[0].id == 2
 
     @pytest.mark.usefixtures('multiple_tils_inserted')
-    def test_til_contains_str_value(self, session, is_sqlite, is_postgresql):
+    def test_til_contains_str_value(
+        self, session, is_sqlite, is_postgresql, is_sqlalchemy_1_3_or_higer
+    ):
         if is_sqlite:
             pytest.skip()
 
         if is_postgresql:
+            pytest.skip()
+
+        if not is_sqlalchemy_1_3_or_higer:
             pytest.skip()
 
         query = session.query(Til)

--- a/test/models.py
+++ b/test/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from sqlalchemy import (
-    Column, Date, DateTime, ForeignKey, Integer, String, Time, JSON
+    Column, Date, DateTime, ForeignKey, Integer, String, Time
 )
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.ext.declarative import declarative_base
@@ -64,8 +64,15 @@ class Corge(BasePostgresqlSpecific):
     tags = Column(ARRAY(String, dimensions=1))
 
 
-class Til(Base):
+try:
+    from sqlalchemy import JSON
+except ImportError:
+    class Til(Base):
 
-    __tablename__ = 'til'
+        __tablename__ = 'til'
+else:
+    class Til(Base):
 
-    refer_info = Column(JSON)
+        __tablename__ = 'til'
+
+        refer_info = Column(JSON)

--- a/test/models.py
+++ b/test/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from sqlalchemy import (
-    Column, Date, DateTime, ForeignKey, Integer, String, Time
+    Column, Date, DateTime, ForeignKey, Integer, String, Time, JSON
 )
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.ext.declarative import declarative_base
@@ -62,3 +62,10 @@ class Corge(BasePostgresqlSpecific):
     __tablename__ = 'corge'
 
     tags = Column(ARRAY(String, dimensions=1))
+
+
+class Til(Base):
+
+    __tablename__ = 'til'
+
+    refer_info = Column(JSON)

--- a/test/models.py
+++ b/test/models.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import sqlalchemy
 from sqlalchemy import (
     Column, Date, DateTime, ForeignKey, Integer, String, Time
 )
@@ -64,15 +65,14 @@ class Corge(BasePostgresqlSpecific):
     tags = Column(ARRAY(String, dimensions=1))
 
 
-try:
-    from sqlalchemy import JSON
-except ImportError:
-    class Til(Base):
+if sqlalchemy.__version__ >= '1.3.0':
 
-        __tablename__ = 'til'
-else:
+    from sqlalchemy import JSON
+
     class Til(Base):
 
         __tablename__ = 'til'
 
         refer_info = Column(JSON)
+else:
+    Til = None


### PR DESCRIPTION
# Intro
1. Add new Operator `json_contains` to support JSON field in mysql5.7 or higher
2. Add mysql test for `json_contains` and ignore `sqlite` and `postgres`
3. Only support sqlalchemy1.3.x or higher for now

## More
1. Not sure format is correct for this repo.
2. Please let me know if there is something necessary need to add for this PR.

## Confused
1. Can't find sqlite3 version, and sqlalchemy1.1.x or higher support `JSON` but sqlite will raise an says that:
```
 CompileError: (in table 'til', column 'refer_info'): Compiler <sqlalchemy.dialects.sqlite.base.SQLiteTypeCompiler object at 0x7f045429d9d0> can't render element of type <class 'sqlalchemy.sql.sqltypes.JSON'>
``` 
I think the error might be cause by sqlalchemy version and restrict it to 1.3.x or higher then test pass.

but still can't figure out why sqlalchemy1.1 and sqlalchemy1.2 will raise such error with sqlite3,  any idea about this?