### PR TITLE
fix(models): Check for None entity when getting query models

### DIFF
--- a/sqlalchemy_filters/models.py
+++ b/sqlalchemy_filters/models.py
@@ -76,7 +76,7 @@ def get_query_models(query):
         if model_class not in models:
             models.append(model_class)
 
-    return {model.__name__: model for model in models}
+    return {model.__name__: model for model in models if model is not None}
 
 
 def get_model_from_spec(spec, query, default_model=None):


### PR DESCRIPTION
Under some circunstances, such as prepping an aliased subquery to be joined later on, the model entity is missing,
provoking an error when trying to apply filters.