### PR TITLE
Add support for sqlalchemy 1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(here, 'README.rst'), 'r', 'utf-8') as handle:
 
 setup(
     name='sqlalchemy-filters',
-    version='0.12.0',
+    version='0.13.0',
     description='A library to filter SQLAlchemy queries.',
     long_description=readme,
     long_description_content_type='text/x-rst',
@@ -46,6 +46,8 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Database",
         "Topic :: Database :: Front-Ends",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/sqlalchemy_filters/models.py
+++ b/sqlalchemy_filters/models.py
@@ -1,3 +1,4 @@
+import sqlalchemy
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm.mapper import Mapper
@@ -5,6 +6,13 @@ from sqlalchemy.util import symbol
 import types
 
 from .exceptions import BadQuery, FieldNotFound, BadSpec
+
+
+try:
+    from sqlalchemy import Table
+    from sqlalchemy.sql.selectable import Alias
+except ImportError:
+    pass
 
 
 class Field(object):
@@ -51,8 +59,80 @@ def _is_hybrid_method(orm_descriptor):
     return orm_descriptor.extension_type == symbol('HYBRID_METHOD')
 
 
-def get_query_models(query):
-    """Get models from query.
+def _get_tables_from_join(orm_join):
+    models = []
+    if isinstance(orm_join.right, Table):
+        models.append(orm_join.right)
+    elif isinstance(orm_join.right, Alias):
+        pass
+    else:
+        models.extend(_get_tables_from_join(orm_join.right))
+    if isinstance(orm_join.left, Table):
+        models.append(orm_join.left)
+    elif isinstance(orm_join.right, Alias):
+        pass
+    else:
+        models.extend(_get_tables_from_join(orm_join.left))
+    return models
+
+
+def _get_model_class_by_table_name(registry, tablename):
+    """ Return the model class matching `tablename` in the given `registry`.
+    """
+    for cls in registry.values():
+        if hasattr(cls, '__tablename__') and cls.__tablename__ == tablename:
+            return cls
+
+
+def _get_query_models_1_4(query):
+    """Get models from query. Works for sqlalchemy 1.4
+
+    :param query:
+        A :class:`sqlalchemy.orm.Query` instance.
+
+    :returns:
+        A dictionary with all the models included in the query.
+    """
+    models = [col_desc['entity'] for col_desc in query.column_descriptions]
+    if models:
+        try:
+            registry = models[-1].registry._class_registry
+            joined = []
+            for f in query.statement.get_final_froms():
+                if not f._is_join:
+                    continue
+                if isinstance(f, Table):
+                    joined.append(
+                        _get_model_class_by_table_name(registry, f.name)
+                    )
+                else:
+                    joined.extend(
+                        _get_model_class_by_table_name(registry, m.name)
+                        for m in _get_tables_from_join(f)
+                    )
+
+            models.extend([m for m in joined if m not in models])
+        except InvalidRequestError:
+            pass
+
+    tables = query._from_obj
+    select_from_models = [
+        t._annotations['entity_namespace']._identity_class for t in tables
+    ]
+    models.extend([m for m in select_from_models if m not in models])
+
+    tables = query._legacy_setup_joins
+    joined = [
+        t[0]._annotations['entity_namespace']._identity_class
+        for t in tables
+    ]
+    models.extend([m for m in joined if m not in models])
+
+    return {model.__name__: model for model in models if model}
+
+
+def _get_query_models(query):
+    """Get models from query. Works for sqlalchemy < 1.4
 
     :param query:
         A :class:`sqlalchemy.orm.Query` instance.
@@ -77,6 +157,20 @@ def get_query_models(query):
             models.append(model_class)
 
     return {model.__name__: model for model in models}
+
+
+def get_query_models(query):
+    """Get models from query.
+
+    :param query:
+        A :class:`sqlalchemy.orm.Query` instance.
+
+    :returns:
+        A dictionary with all the models included in the query.
+    """
+    if sqlalchemy.__version__ > '1.3':
+        return _get_query_models_1_4(query)
+    return _get_query_models(query)
 
 
 def get_model_from_spec(spec, query, default_model=None):
@@ -146,9 +240,9 @@ def get_default_model(query):
     return default_model
 
 
-def auto_join(query, *model_names):
+def _auto_join(query, *model_names):
     """ Automatically join models to `query` if they're not already present
-    and the join can be done implicitly.
+    and the join can be done implicitly. Works for sqlalchemy < 1.4
     """
     # every model has access to the registry, so we can use any from the query
     query_models = get_query_models(query).values()
@@ -162,3 +256,32 @@ def auto_join(query, *model_names):
             except InvalidRequestError:
                 pass  # can't be autojoined
     return query
+
+
+def _auto_join_1_4(query, *model_names):
+    """ Automatically join models to `query` if they're not already present
+    and the join can be done implicitly. Works for sqlalchemy 1.4
+    """
+    # every model has access to the registry, so we can use any from the query
+    query_models = get_query_models(query).values()
+    model_registry = list(query_models)[-1].registry._class_registry
+
+    for name in model_names:
+        model = get_model_class_by_name(model_registry, name)
+        if model and model not in get_query_models(query).values():
+            try:
+                tmp_query = query.join(model)
+                tmp_query.statement.compile()
+                query = tmp_query
+            except InvalidRequestError:
+                pass  # can't be autojoined
+    return query
+
+
+def auto_join(query, *model_names):
+    """ Automatically join models to `query` if they're not already present
+    and the join can be done implicitly.
+    """
+    if sqlalchemy.__version__ < '1.4':
+        return _auto_join(query, *model_names)
+    return _auto_join_1_4(query, *model_names)

--- a/test/interface/test_models.py
+++ b/test/interface/test_models.py
@@ -1,5 +1,6 @@
 import pytest
 from sqlalchemy import func
+import sqlalchemy
 from sqlalchemy.orm import joinedload
 
 from sqlalchemy_filters.exceptions import BadSpec, BadQuery
@@ -132,7 +133,9 @@ class TestGetModelClassByName:
 
     @pytest.fixture
     def registry(self):
-        return Base._decl_class_registry
+        if sqlalchemy.__version__ < '1.4':
+            return Base._decl_class_registry
+        return Base.registry._class_registry
 
     def test_exists(self, registry):
         assert get_model_class_by_name(registry, 'Foo') == Foo

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35,py36,py37,py38}-sqlalchemy{1.0,1.1,1.2,1.3,latest}
+envlist = {py27,py35,py36,py37,py38,py39,py310}-sqlalchemy{1.0,1.1,1.2,1.3,latest}
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
I added support for sqlalchemy 1.4+ without breaking support for older versions. sqlalchemy 1.4 has big differences in internals from 1.3 - so I created separate methods for a newer version. 