### PR TITLE
pin mariadb to the lts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:latest
+        image: mariadb:10
         ports:
           - 3306:3306
         env:


### PR DESCRIPTION
Not sure why, but the latest mariadb [broke the tests](https://github.com/juliotrigo/sqlalchemy-filters/actions/runs/7433896014?pr=84) and pinning it to the last version, that's actually the LTS, fixes it